### PR TITLE
Fix geonodeadmin.bootstrap arguments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 dominode_bootstrapper.egg-info
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/__pycache__
 
 *.egg-info/
+
+.python-version

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Install
 
 This uses `poetry`_, so clone this project, install poetry and then::
 
-    cd extra/dominode-bootstrapper
+    cd dominode-bootstrapper
     poetry install
 
 

--- a/dominode_bootstrapper/dominodeadmin.py
+++ b/dominode_bootstrapper/dominodeadmin.py
@@ -55,10 +55,10 @@ def bootstrap(
     )
     geonodeadmin.bootstrap(
         geonode_base_url=config['geonode']['base_url'],
-        geonode_username=config['geonode']['admin_username'],
-        geonode_password=config['geonode']['admin_password'],
+        geonode_admin_username=config['geonode']['admin_username'],
+        geonode_admin_password=config['geonode']['admin_password'],
         geoserver_base_url=config['geoserver']['base_url'],
-        geoserver_username=config['geoserver']['admin_username'],
-        geoserver_password=config['geoserver']['admin_password']
+        geoserver_admin_username=config['geoserver']['admin_username'],
+        geoserver_admin_password=config['geoserver']['admin_password']
     )
     typer.echo('Done!')


### PR DESCRIPTION
When I run it for this PR: https://github.com/dominodeorg/dominode/pull/98 , it failed because it had the wrong kwargs.
Not sure which one was supposed to be changed but I guess changing the passed args are the least-effort.