### PR TITLE
Restrict DB access for default geoserver DB users

### DIFF
--- a/dominode_bootstrapper/dbadmin.py
+++ b/dominode_bootstrapper/dbadmin.py
@@ -270,7 +270,6 @@ def bootstrap_department(
         utils.get_geoserver_db_username(department),
         geoserver_password,
         db_connection,
-        parent_roles=[generic_user_name]
     )
     if department == 'lsd':
         bootstrap_lsd_topomaps(db_connection, user_role)


### PR DESCRIPTION
This PR restricts access privileges for the default geoserver users that are used to configure the default PostGIS stores in GeoServer.

GeoServer DB users from each department can now only access their own department's tables on the `public` schema. In addition, GeoServer DB users cannot access other schemas.

The proposed implmentation relies on the usage of the `DomiNodeMoveTableToPublicSchema()` function.

- geoserver DB users are not children of the `dominode_user` role anymore. This means they cannot access any of the internal schemas;

- when using the `DomiNodeMoveTableToPublicSchema()` function:

  - `SELECT` privilege is now revoked from regular DB users
  - `SELECT` privilege is granted to `dominode_user` role
  - `SELECT` privilege is granted to the geoserver user of the relevant department