### PR TITLE
Add additional `qgis_projects` table to common staging schema

### DIFF
--- a/dominode_bootstrapper/dbadmin.py
+++ b/dominode_bootstrapper/dbadmin.py
@@ -85,6 +85,12 @@ def bootstrap(
             ('USAGE', 'CREATE'),
             config['dominode']['generic_user_name'], db_connection
         )
+        typer.echo(f'Creating qgis_projects table...')
+        create_qgis_projects_table(
+            db_connection,
+            dominode_staging_schema_name,
+            config['dominode']['generic_user_name']
+        )
         for department in utils.get_departments(config):
             typer.echo(f'Bootstrapping {department} department...')
             bootstrap_department(


### PR DESCRIPTION
This table allows sharing qgis projects between all departments. It is owned by the `dominode_user` role, from which all other department users inherit.

Every user from a department is thus able to save and load QGIS projects into/from this table

fixes #8